### PR TITLE
CCP-1406: Updated for a typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
  All notable changes to this project will be documented in this file.
  The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3] - 2019-03-21
+Fixed a typo.
+
 ## [1.0.2] - 2019-03-21
 Additional styling.
 
@@ -15,6 +18,7 @@ First version of the extension.
 - You can configure a Yotpo app key for specific merchant.
 - Connect to write a Review is not included in this integration.
 
+[1.0.3]: https://github.com/shopgate-professional-services/ext-yotpo-reviews/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/shopgate-professional-services/ext-yotpo-reviews/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/shopgate-professional-services/ext-yotpo-reviews/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/shopgate-professional-services/ext-yotpo-reviews/compare/v0.0.1...v1.0.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add the yotpo-reviews extension to your Shopgate Connect deployment config.
 (...)
   {
     "id": "@shopgate-project/yotpo-reviews",
-    "version": "1.0.2"
+    "version": "1.0.3"
   }
 (...)
 ```

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "id": "@shopgate-project/yotpo-reviews",
   "components": [
     {

--- a/frontend/components/HtmlReferenceContainer/components/YotpoWidget/style.js
+++ b/frontend/components/HtmlReferenceContainer/components/YotpoWidget/style.js
@@ -11,7 +11,7 @@ const container = css({
   maxWidth: '100%',
   wordWrap: 'break-word',
   wordBreak: 'break-word',
-  '.socialize-wrapper, .yotpo-icon-three-lines, .yotpo-bottomline-empty-state': {
+  ' .socialize-wrapper, .yotpo-icon-three-lines, .yotpo-bottomline-empty-state': {
     display: 'none !important',
   },
   ' .yotpo-menu-mobile-collapse': {

--- a/frontend/config.json
+++ b/frontend/config.json
@@ -1,3 +1,0 @@
-{
-  "yotpoAppKey": "Jef9OB604CTlOdKzDGy4J9VohHwktePlzRaEEO1w"
-}

--- a/frontend/config.json
+++ b/frontend/config.json
@@ -1,3 +1,3 @@
 {
-  "yotpoAppKey": "LHgQXH7Uj3KgqA8WkfUEfwsf9gMzKi3acoVoU8on"
+  "yotpoAppKey": "Jef9OB604CTlOdKzDGy4J9VohHwktePlzRaEEO1w"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-ps/yotpo-reviews",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Allows customers to leave and read yotpo reviews for merchant's products",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
There was a typo in frontend/components.HtmlREferenceContainer/components/YotpoWidget/style.js that kept display: none rule from applying.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
